### PR TITLE
Update Redis gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
-gem 'redis', '~> 3.0'
+gem 'redis', '~> 4.1.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -654,7 +654,7 @@ GEM
       rdf (~> 3.1)
     redic (1.5.3)
       hiredis
-    redis (3.3.5)
+    redis (4.1.4)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
     redlock (1.2.0)
@@ -861,7 +861,7 @@ DEPENDENCIES
   mysql2
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.3)
-  redis (~> 3.0)
+  redis (~> 4.1.0)
   riiif (~> 2.0)
   rsolr (>= 1.0, < 3)
   rspec-rails


### PR DESCRIPTION
The version of the redis gem is too old and producing the error below on the dashboard.

<img width="1424" alt="Screen Shot 2020-10-02 at 10 52 07 AM" src="https://user-images.githubusercontent.com/5639859/94966537-743da000-04cb-11eb-8334-72c664aa7eed.png">
