### PR TITLE
configure settings for iiif image server

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,6 @@
 # Application
 UC_DRC_APPLICATION_URL=http://localhost:3000
-UC_DRC_JOB_QUEUE_ADAPTER=:inline
+UC_DRC_JOB_QUEUE_ADAPTER=:sidekiq
 UC_DRC_PRODUCTION_MAILER_URL=localhost:3000
 
 # Browse Everything
@@ -32,6 +32,11 @@ UC_DRC_FITS_PATH=fits.sh
 # Fixity
 FIXITY_MAX_DAYS=-1
 
+# IIIF 
+UC_DRC_IIIF_IMAGE_SERVER=true
+# Uncomment to use cantaloupe image server
+# UC_DRC_IIIF_SERVER_URL=http://localhost:8182/iiif/2/
+
 # Google Analytics
 UC_DRC_ANALYTICS_TOGGLE=false
 UC_DRC_ANALYTICS_ID=analytics_id
@@ -40,7 +45,7 @@ UC_DRC_ANALYTICS_PRIVKEY_SECRET=analytics_privkey_secret
 UC_DRC_ANALYTICS_CLIENT_EMAIL=analytics_client_email
 
 # Redis
-UC_DRC_REDIS_HOST=redis
+UC_DRC_REDIS_HOST=localhost
 
 # Samvera
 UC_DRC_CACHE_PATH=/tmp/cache

--- a/.env.development.docker
+++ b/.env.development.docker
@@ -1,6 +1,6 @@
 # Application
 UC_DRC_APPLICATION_URL=http://localhost:3000
-UC_DRC_JOB_QUEUE_ADAPTER=:inline
+UC_DRC_JOB_QUEUE_ADAPTER=:sidekiq
 UC_DRC_PRODUCTION_MAILER_URL=localhost:3000
 
 # Browse Everything
@@ -32,6 +32,10 @@ UC_DRC_FITS_PATH=/opt/fits/fits.sh
 # Fixity
 FIXITY_MAX_DAYS=-1
 
+# IIIF
+UC_DRC_IIIF_IMAGE_SERVER=true
+UC_DRC_IIIF_SERVER_URL=http://localhost:8182/iiif/2/
+
 # Google Analytics
 UC_DRC_ANALYTICS_TOGGLE=false
 UC_DRC_ANALYTICS_ID=analytics_id
@@ -43,12 +47,12 @@ UC_DRC_ANALYTICS_CLIENT_EMAIL=analytics_client_email
 UC_DRC_REDIS_HOST=redis
 
 # Samvera
-UC_DRC_CACHE_PATH=/tmp/cache
-UC_DRC_DERIVATIVES_PATH=/tmp/derivatives
+UC_DRC_CACHE_PATH=/opt/hyrax/tmp/cache
+UC_DRC_DERIVATIVES_PATH=/opt/hyrax/tmp/derivatives
 UC_DRC_FEDORA_PASSWORD=fedoraAdmin
 UC_DRC_FEDORA_URL=http://fcrepo:8984/fcrepo/rest
-UC_DRC_MINTER_STATE_FILE=/tmp/minter-state
-UC_DRC_RIIIF_CACHE=/tmp/riiif
+UC_DRC_MINTER_STATE_FILE=/opt/hyrax/tmp/minter-state
+UC_DRC_RIIIF_CACHE=/opt/hyrax/tmp/riiif
 UC_DRC_SOFFICE_PATH=soffice
 UC_DRC_SOLR_URL=http://solr:8983/solr/development
-UC_DRC_UPLOAD_PATH=/tmp/uploads
+UC_DRC_UPLOAD_PATH=/opt/hyrax/tmp/uploads

--- a/Gemfile
+++ b/Gemfile
@@ -81,8 +81,7 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 group :development, :test do
   gem 'dotenv-rails'
   gem 'fcrepo_wrapper'
+  gem 'riiif', '~> 2.0'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails'
 end
-
-gem 'riiif', '~> 2.0'

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -138,20 +138,27 @@ Hyrax.config do |config|
   #   * iiif_image_size_default
   #
   # Default is false
-  # config.iiif_image_server = false
+  config.iiif_image_server = ENV['UC_DRC_IIIF_IMAGE_SERVER']
 
   # Returns a URL that resolves to an image provided by a IIIF image server
   config.iiif_image_url_builder = lambda do |file_id, base_url, size|
-    Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size)
+    if ENV['UC_DRC_IIIF_SERVER_URL'].present?
+      iiifurl = ENV['UC_DRC_IIIF_SERVER_URL'] + file_id.gsub('/', '%2F') + '/full/' + size + '/0/default.jpg'
+      Rails.logger.debug "event: iiif_image_request: #{iiifurl}"
+      iiifurl
+    else
+      Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size)
+    end
   end
-  # config.iiif_image_url_builder = lambda do |file_id, base_url, size|
-  #   "#{base_url}/downloads/#{file_id.split('/').first}"
-  # end
 
   # Returns a URL that resolves to an info.json file provided by a IIIF image server
   config.iiif_info_url_builder = lambda do |file_id, base_url|
-    uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)
-    uri.sub(%r{/info\.json\Z}, '')
+    if ENV['UC_DRC_IIIF_SERVER_URL'].present?
+      ENV['UC_DRC_IIIF_SERVER_URL'] + file_id.gsub('/', '%2F')
+    else
+      uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)
+      uri.sub(%r{/info\.json\Z}, '')
+    end
   end
   # config.iiif_info_url_builder = lambda do |_, _|
   #   ""
@@ -161,7 +168,7 @@ Hyrax.config do |config|
   # config.iiif_image_compliance_level_uri = 'http://iiif.io/api/image/2/level2.json'
 
   # Returns a IIIF image size default
-  # config.iiif_image_size_default = '600,'
+  config.iiif_image_size_default = 'full'
 
   # Fields to display in the IIIF metadata section; default is the required fields
   # config.iiif_metadata_fields = Hyrax::Forms::WorkForm.required_fields

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
+  # Bypass Riiif if custom image server present
+  unless ENV['UC_DRC_IIIF_SERVER_URL'].present?
+    mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
+  end
   mount BrowseEverything::Engine => '/browse'
-
   mount Blacklight::Engine => '/'
 
   concern :searchable, Blacklight::Routes::Searchable.new


### PR DESCRIPTION
Fixes #72 

Configure for custom iiif image server (cantaloupe)

Changes proposed in this pull request:
* Add URL constructor for iiif server
* Add environment variables to toggle between riiif and cantaloupe
* Switch on sidekiq for jobs processing
* Move riiif to dev only in Gemfile
