### PR TITLE
Add hydra-role-management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby '2.7.1'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.4', '>= 5.2.4.3'
 # Use sqlite3 as the database for Active Record
+gem 'hydra-role-management'
 gem 'hyrax', '2.8.0'
 gem 'mysql2'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,9 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    bootstrap_form (4.5.0)
+      actionpack (>= 5.2)
+      activemodel (>= 5.2)
     breadcrumbs_on_rails (3.0.1)
     browse-everything (1.0.2)
       addressable (~> 2.5)
@@ -342,6 +345,12 @@ GEM
     hydra-pcdm (1.1.0)
       active-fedora (>= 10, < 14)
       mime-types (>= 1)
+    hydra-role-management (1.0.3)
+      blacklight
+      bootstrap_form
+      bundler (>= 1.5)
+      cancancan
+      json (>= 1.8)
     hydra-works (1.2.0)
       activesupport (>= 4.2.10, < 6.0)
       hydra-derivatives (~> 3.0)
@@ -854,6 +863,7 @@ DEPENDENCIES
   devise-guests (~> 0.6)
   dotenv-rails
   fcrepo_wrapper
+  hydra-role-management
   hyrax (= 2.8.0)
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,8 +8,10 @@ class Ability
 
   # Define any customized permissions here.
   def custom_permissions
-    # Limits deleting objects to a the admin user
+    can %i[create show add_user remove_user index edit update destroy], Role if current_user.admin?
+
     #
+    # Limits deleting objects to a the admin user
     # if current_user.admin?
     #   can [:destroy], ActiveFedora::Base
     # end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,9 @@
 class User < ApplicationRecord
   # Connects this user object to Hydra behaviors.
   include Hydra::User
+  # Connects this user object to Role-management behaviors.
+  include Hydra::RoleManagement::UserRoles
+
   # Connects this user object to Hyrax behaviors.
   include Hyrax::User
   include Hyrax::UserUsageStats

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     concerns :searchable
   end
   devise_for :users
+  mount Hydra::RoleManagement::Engine => '/'
+
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'

--- a/db/migrate/20201015183531_user_roles.rb
+++ b/db/migrate/20201015183531_user_roles.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class UserRoles < ActiveRecord::Migration[5.0]
+  def up
+    create_table :roles do |t|
+      t.string :name
+    end
+    create_table :roles_users, id: false do |t|
+      t.references :role
+      t.references :user
+    end
+    add_index :roles_users, %i[role_id user_id]
+    add_index :roles_users, %i[user_id role_id]
+  end
+
+  def down
+    drop_table :roles_users
+    drop_table :roles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_01_191241) do
+ActiveRecord::Schema.define(version: 2020_10_15_183531) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -281,6 +281,19 @@ ActiveRecord::Schema.define(version: 2020_07_01_191241) do
     t.datetime "updated_at", null: false
     t.index ["local_authority_id"], name: "index_qa_local_authority_entries_on_local_authority_id"
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
+  end
+
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "roles_users", id: false, force: :cascade do |t|
+    t.integer "role_id"
+    t.integer "user_id"
+    t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
+    t.index ["role_id"], name: "index_roles_users_on_role_id"
+    t.index ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
+    t.index ["user_id"], name: "index_roles_users_on_user_id"
   end
 
   create_table "searches", force: :cascade do |t|

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'cancan/matchers'
+
+RSpec.describe Ability, type: :model do
+  it 'responds to :custom_permissions' do
+    expect(described_class.method_defined?(:custom_permissions)).to be true
+  end
+end


### PR DESCRIPTION
Fixes #88 

Add hydra-role-management gem and configure admin ability for role management.

Changes proposed in this pull request:
* Add hydra-role-management
* Add add admin role manegment
* Add spec for abilities model.
