### PR TITLE
Create default users and collection types

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
     * ```admin.users << User.find_by_user_key( "your_admin_users_email@fake.email.org" )```
     * ```admin.save```
     * Read [more](https://github.com/samvera/hyrax/wiki/Making-Admin-Users-in-Hyrax).
+1. Generate example/test users with roles ```bin/rails db:seed```
+    * Read [more](https://github.com/uclibs/uc_drc/blob/master/db/seeds.rb)
 
 ## Running the Tests
 1. Start fedora: ```fcrepo_wrapper -p 8986```

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,40 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+password = 'password'
+
+puts "Password for all accounts: #{password}\n\n"
+
+if test_user = User.find_by_email('test@example.com')
+  test_user.update(
+    password: password,
+    password_confirmation: password)
+  puts "Account updated: #{test_user.email}"
+else
+  test_user = User.create(
+    email: 'test@example.com',
+    display_name: 'Test User',
+    password: password,
+    password_confirmation: password)
+  puts "Account created: #{test_user.email}"
+end
+
+if admin_user = User.find_by_email('admin@example.com')
+  admin_user.update(
+    password: password,
+    password_confirmation: password)
+  admin = Role.find_or_create_by(name: 'admin')
+  admin.users << admin_user
+  admin.save
+  puts "Account updated: #{admin_user.email}"
+else
+  admin_user = User.create(
+    email: 'admin@example.com',
+    display_name: 'Admin User',
+    password: password,
+    password_confirmation: password)
+  admin = Role.find_or_create_by(name: 'admin')
+  admin.users << admin_user
+  admin.save
+  puts "Account created: #{admin_user.email}\n\n"
+end

--- a/docker/web/scripts/docker-entrypoint.sh
+++ b/docker/web/scripts/docker-entrypoint.sh
@@ -40,6 +40,9 @@ if [ "$1" = 'server' ]; then
     echo "Initialize Default Admin Set"
     bundle exec rake hyrax:default_admin_set:create
 
+    echo "create default collection types"
+    bundle exec rake hyrax:default_collection_types:create
+
     echo "Starting the Rails Server"
     exec bundle exec rails s -b 0.0.0.0
 


### PR DESCRIPTION
Fixes #84 
Fixes #99 

Changes proposed in this pull request:
* Add default/example users to db:seeds
* Execute default collection types rake task in docker build
