### PR TITLE
sandbox deploy script

### DIFF
--- a/scripts/pull-drc-main.sh
+++ b/scripts/pull-drc-main.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Bash script to pull current main branch and build in docker
+# - created for auto deployment to sandbox
+
+docker-compose -f /opt/rails-apps/deric/uc_drc/docker-compose.yml down
+cd /opt/rails-apps/deric/uc_drc && git pull 
+docker-compose -f /opt/rails-apps/deric/uc_drc/docker-compose.yml up -d --build
+


### PR DESCRIPTION
Fixes #101 

Added `pull-drc-main.sh` shell script to scripts director for use in auto deploy to sandbox (curly). Use this script in a cron job.

Changes proposed in this pull request:
* Add scripts directory
* Add shell script for auto deployment
