### PR TITLE
add seperate .env variables for docker on curly

### DIFF
--- a/.env.development.docker.curly
+++ b/.env.development.docker.curly
@@ -1,0 +1,58 @@
+# Application
+UC_DRC_APPLICATION_URL=http://localhost:3010
+UC_DRC_JOB_QUEUE_ADAPTER=:sidekiq
+UC_DRC_PRODUCTION_MAILER_URL=localhost:3010
+
+# Browse Everything
+UC_DRC_BROWSE_EVERYTHING_BOX_ID=box_id
+UC_DRC_BROWSE_EVERYTHING_BOX_SECRET=box_secret
+UC_DRC_BROWSE_EVERYTHING_KALTURA_ID=kaltura_id
+UC_DRC_BROWSE_EVERYTHING_KALTURA_SECRET=kaltura_secret
+UC_DRC_BROWSE_EVERYTHING_DROPBOX_ID=dropbox_id
+UC_DRC_BROWSE_EVERYTHING_DROPBOX_SECRET=dropbox_secret
+UC_DRC_BROWSE_EVERYTHING_GOOGLE_ID=google_id
+UC_DRC_BROWSE_EVERYTHING_GOOGLE_SECRET=google_secret
+
+# Database settings
+UC_DRC_DATABASE_ADAPTER=mysql2
+UC_DRC_DATABASE_HOST=db
+UC_DRC_DATABASE_NAME=hyrax
+UC_DRC_DATABASE_PASSWORD=root
+UC_DRC_DATABASE_POOL=5
+UC_DRC_DATABASE_PORT=3306
+UC_DRC_DATABASE_TIMEOUT=5000
+UC_DRC_DATABASE_USERNAME=root
+
+# Devise
+UC_DRC_DEVISE_KEY=devise_secret_key
+
+#FITS
+UC_DRC_FITS_PATH=/opt/fits/fits.sh
+
+# Fixity
+FIXITY_MAX_DAYS=-1
+
+# IIIF
+UC_DRC_IIIF_IMAGE_SERVER=true
+UC_DRC_IIIF_SERVER_URL=http://curly.libraries.uc.edu:8182/iiif/2/
+
+# Google Analytics
+UC_DRC_ANALYTICS_TOGGLE=false
+UC_DRC_ANALYTICS_ID=analytics_id
+UC_DRC_ANALYTICS_PRIVKEY_PATH=analytics_privkey_path
+UC_DRC_ANALYTICS_PRIVKEY_SECRET=analytics_privkey_secret
+UC_DRC_ANALYTICS_CLIENT_EMAIL=analytics_client_email
+
+# Redis
+UC_DRC_REDIS_HOST=redis
+
+# Samvera
+UC_DRC_CACHE_PATH=/opt/hyrax/tmp/cache
+UC_DRC_DERIVATIVES_PATH=/opt/hyrax/tmp/derivatives
+UC_DRC_FEDORA_PASSWORD=fedoraAdmin
+UC_DRC_FEDORA_URL=http://fcrepo:8984/fcrepo/rest
+UC_DRC_MINTER_STATE_FILE=/opt/hyrax/tmp/minter-state
+UC_DRC_RIIIF_CACHE=/opt/hyrax/tmp/riiif
+UC_DRC_SOFFICE_PATH=soffice
+UC_DRC_SOLR_URL=http://solr:8983/solr/development
+UC_DRC_UPLOAD_PATH=/opt/hyrax/tmp/uploads

--- a/docker/web/scripts/docker-entrypoint.sh
+++ b/docker/web/scripts/docker-entrypoint.sh
@@ -23,7 +23,12 @@ if [ "$1" = 'server' ]; then
     fi
 
     echo "Copy over Docker env variables"
-    /bin/cp -f .env.development.docker .env.development.local
+    
+    if [$(hostname) = 'curly']; then
+      /bin/cp -f .env.development.docker.curly .env.development.local
+    else 
+      /bin/cp -f .env.development.docker .env.development.local
+    fi
 
     echo "Install bundler"
     gem install bundler:2.0.2


### PR DESCRIPTION
Fixes #102 

Docker builds on curly had 'localhost' env set for cantaloupe url. While this works in local environment, the url needs to have curly hostname on curly to function properly.

Changes proposed in this pull request:
* Add curly specific .env file
* Check hostname during docker build to select correct file between local and curly
