### PR TITLE
make hostname available from docker host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     environment:
       RAILS_ENV: development
       HYRAX_DB_HOST: db
+      DOCKER_HOST_HOSTNAME: $DOCKER_HOST_HOSTNAME
   worker:
     image: hyrax_web
     depends_on:

--- a/docker/web/scripts/docker-entrypoint.sh
+++ b/docker/web/scripts/docker-entrypoint.sh
@@ -23,8 +23,7 @@ if [ "$1" = 'server' ]; then
     fi
 
     echo "Copy over Docker env variables"
-    
-    if [$(hostname) = 'curly']; then
+    if [[ $(echo $DOCKER_HOST_HOSTNAME) = 'curly' ]]; then
       /bin/cp -f .env.development.docker.curly .env.development.local
     else 
       /bin/cp -f .env.development.docker .env.development.local

--- a/scripts/pull-drc-main.sh
+++ b/scripts/pull-drc-main.sh
@@ -4,5 +4,5 @@
 
 docker-compose -f /opt/rails-apps/deric/uc_drc/docker-compose.yml down
 cd /opt/rails-apps/deric/uc_drc && git pull 
-docker-compose -f /opt/rails-apps/deric/uc_drc/docker-compose.yml up -d --build
+DOCKER_HOST_HOSTNAME=curly docker-compose -f /opt/rails-apps/deric/uc_drc/docker-compose.yml up -d --build
 


### PR DESCRIPTION
Fixes #101 

Make hostname available to docker web container so that we can choose env variables for curly vs localhost.

Changes proposed in this pull request:
* Set `DOCKER_HOST_HOSTNAME` env var in bash script for curly
* Add env var `DOCKER_HOST_HOSTNAME`
* Choose curly specific env vars when hostname is set to curly
