### PR TITLE
[WIP] Pins sassc to version 2.1.0 for docker builds.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem 'sqlite3', '~> 1.3.0'
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
+# Pins because of Docker build problem
+gem 'sassc', '2.1.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,7 +323,7 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
-    ffi (1.13.1)
+    ffi (1.14.2)
     flipflop (2.6.0)
       activesupport (>= 4.0)
     flot-rails (0.0.7)
@@ -809,7 +809,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.4.0)
+    sassc (2.1.0)
       ffi (~> 1.9)
     scanf (1.0.0)
     select2-rails (3.5.10)
@@ -965,6 +965,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   sass-rails (~> 5.0)
+  sassc (= 2.1.0)
   selenium-webdriver
   sidekiq
   simplecov


### PR DESCRIPTION
When docker 3.0.3 attempts to bundle install sassc version 2.4.0 it has a fatal timeout.

Fetching sassc 2.4.0
Installing sassc 2.4.0 with native extensions
/scripts/docker-entrypoint.sh: line 100:    31 Killed                  bundle install

It looks like there is a problem with rails 6, docker, and version 2.4.0.

https://stackoverflow.com/questions/62720043/rails-why-is-bundle-install-frozen-up-by-sassc-2-4-0
