### PR TITLE
Removes depositor and keyword from recent documents partial.

### DIFF
--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -1,0 +1,12 @@
+<li class="recent-item">
+    <div class="row">
+      <div class="col-sm-12">
+        <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
+        <h3>
+          <%= link_to [main_app, recent_document] do %>
+            <%= render_thumbnail_tag(recent_document, {width: 90}, {suppress_link: true}) + recent_document.to_s %>
+          <% end %>
+        </h3>
+      </div>
+    </div>
+</li>


### PR DESCRIPTION
Fixes #103 

Removed this two fields from the recent documents partial since they are having problems with metadata profile.

'''
<p class="recent-field">
          <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.depositor_label') %>:</span> <%= link_to_profile recent_document.depositor(t('hyrax.homepage.recently_uploaded.document.depositor_missing')) %>
        </p>
        <p class="recent-field">
          <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.keyword_label') %>:</span> <%= link_to_facet_list(recent_document.keyword, 'keyword', t('hyrax.homepage.recently_uploaded.document.keyword_missing')).html_safe %>
        </p>
'''
This just leaves title in the partial which is fine for our use cases.

Overwrote : https://raw.githubusercontent.com/samvera/hyrax/2.x-stable/app/views/hyrax/homepage/_recent_document.html.erb