### PR TITLE
Upgrade solr version, tweak config

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:6.1
+FROM solr:7.1
 
 COPY config /opt/solr/server/solr/mycores/development
 COPY config /opt/solr/server/solr/mycores/test


### PR DESCRIPTION
Fixes #115 

After consolidating solr config, the solr container was failing to load the test and dev cores. The consolidation used the solr config bundled with the app but the Dockerfile was configured for the standalone. Upgrade the solr version to 7.1 and add a missing core.properties file.


Changes proposed in this pull request:
* bump solr version
* add core.properties file
