### PR TITLE
check for existing metadata profile for loading in rake task

### DIFF
--- a/lib/tasks/metadata_profile.rake
+++ b/lib/tasks/metadata_profile.rake
@@ -3,6 +3,9 @@
 namespace :metadata_profile do
   desc 'Load default metadata profile'
   task load_default: :environment do
-    AllinsonFlex::Importer.load_profile_from_path(path: 'config/metadata_profile/uc_drc.yaml')
+    unless AllinsonFlex::Profile.positive?
+      puts 'Load default metadata profile'
+      AllinsonFlex::Importer.load_profile_from_path(path: Rails.root.join('config', 'metadata_profile', 'uc_drc.yml'))
+    end
   end
 end


### PR DESCRIPTION
Fixes #118 

App container crashes on docker build when default metadata profile load task runs into validation failure because it's already been loaded.

Add a conditional to check for presence of a metadata profile.

Changes proposed in this pull request:
* add conditional check for existing metadata profile

