### PR TITLE
overwrite .env.development file in docker

### DIFF
--- a/docker/app/scripts/docker-entrypoint.sh
+++ b/docker/app/scripts/docker-entrypoint.sh
@@ -26,7 +26,7 @@ if [ "$1" = 'server' ]; then
     if [[ $(echo $DOCKER_HOST_HOSTNAME) = 'curly' ]]; then
       /bin/cp -f .env.development.docker.curly .env.development.local
     else 
-      /bin/cp -f .env.development.docker .env.development.local
+      /bin/cp -f .env.development.docker .env.development
     fi
 
     echo "Install bundler"


### PR DESCRIPTION
Fixes #117 

Overwrite .env.development file instead of .local in docker builds
